### PR TITLE
Add parameter stop_time to SymbolicRegression class

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ X_train, X_test, y_train, y_test = train_test_split(X, y)
 ```
 Finally we'll create and fit the Symbolic Regression estimator and check the score.
 ```python
-sr = SymbolicRegression(ngen=100, pop_size=100)
+sr = SymbolicRegression(ngen=100, pop_size=100, stop_time=60)
 sr.fit(X_train, y_train)
 score = sr.score(X_test, y_test)
 print('Score: {}'.format(score))

--- a/fastsr/estimators/symbolic_regression.py
+++ b/fastsr/estimators/symbolic_regression.py
@@ -115,6 +115,10 @@ class SymbolicRegression(BaseEstimator):
         Number of lowest error individuals from best_individuals_ to use
         when making predictions and scoring the model.
 
+    stop_time : None or integer
+        Maximum number of seconds to run the optimization; return current
+        optimum after that.
+
     Attributes
     ----------
     population_ : list
@@ -177,7 +181,8 @@ class SymbolicRegression(BaseEstimator):
                  subset_change_frequency=10,
                  num_randoms=1,
                  seed=np.random.randint(10**6),
-                 ensemble_size=1):
+                 ensemble_size=1,
+                 stop_time=None):
 
         self.experiment_class = experiment_class
         self.num_features = num_features
@@ -201,6 +206,7 @@ class SymbolicRegression(BaseEstimator):
         self.num_randoms = num_randoms
         self.ensemble_size = ensemble_size
         self.seed = seed
+        self.stop_time = stop_time
 
     def initialize_defaults(self, X):
         self.num_features = X.shape[1]
@@ -244,7 +250,8 @@ class SymbolicRegression(BaseEstimator):
                                                  max_gen_grow=self.max_gen_grow,
                                                  subset_proportion=self.subset_proportion,
                                                  subset_change_frequency=self.subset_change_frequency,
-                                                 num_randoms=self.num_randoms)
+                                                 num_randoms=self.num_randoms,
+                                                 stop_time=self.stop_time)
         if not hasattr(self, 'pset_'):
             self.pset_ = self.experiment_.get_pset(X.shape[1], self.variable_type_indices, self.variable_names,
                                                    self.variable_dict)
@@ -347,7 +354,8 @@ class SymbolicRegression(BaseEstimator):
                                                  max_gen_grow=self.max_gen_grow,
                                                  subset_proportion=self.subset_proportion,
                                                  subset_change_frequency=self.subset_change_frequency,
-                                                 num_randoms=self.num_randoms)
+                                                 num_randoms=self.num_randoms,
+                                                 stop_time=self.stop_time)
         self.pset_ = self.experiment_.get_pset(self.num_features, self.variable_type_indices, self.variable_names,
                                                self.variable_dict)
         # Create a temporary 'Fake' toolbox such that creator gets initialized with what it needs to create the

--- a/fastsr/experiments/afpo_complexity.py
+++ b/fastsr/experiments/afpo_complexity.py
@@ -39,7 +39,8 @@ class AfpoComplexity(abstract_experiment.Experiment):
                  subset_proportion=1,
                  subset_change_frequency=10,
                  error_function=metrics.mean_squared_error,
-                 num_randoms=1):
+                 num_randoms=1,
+                 stop_time=None):
 
         super(AfpoComplexity, self).__init__()
         self.ngen = ngen
@@ -63,6 +64,7 @@ class AfpoComplexity(abstract_experiment.Experiment):
         self.multi_archive = None
         self.pop = None
         self.mstats = None
+        self.stop_time = stop_time
 
     def get_toolbox(self, predictors, response, pset, variable_type_indices, variable_names):
         subset_size = int(math.floor(predictors.shape[0] * self.subset_proportion))
@@ -125,7 +127,7 @@ class AfpoComplexity(abstract_experiment.Experiment):
                          xover_prob=self.xover_prob, mut_prob=self.mut_prob, ngen=self.ngen,
                          tournament_size=self.tournament_size,  num_randoms=self.num_randoms, stats=self.mstats,
                          archive=self.multi_archive, calc_pareto_front=False, verbose=False, reevaluate_population=True,
-                         history=self.history)
+                         history=self.history, stop_time=self.stop_time)
         toolbox.register("save", reports.save_log_to_csv)
         toolbox.decorate("save", reports.save_archive(self.multi_archive))
         return toolbox


### PR DESCRIPTION
A new parameter stop_time was added to SymbolicRegression to allow limiting the
maximum runtime of the optimization. This may be useful if the feasible number of generations is not known in advance. The new feature relies on PR https://github.com/cfusting/fastgp/pull/2 to the underlying fastgp package.